### PR TITLE
Irredundant constraints

### DIFF
--- a/src/Constraints.hs
+++ b/src/Constraints.hs
@@ -21,34 +21,35 @@ import Constructors
 import Control.Monad.RWS hiding (guard)
 import Data.Bifunctor
 import qualified Data.HashMap.Lazy as HM
-import qualified Data.HashSet as HS
 import Data.Hashable
-import qualified Data.IntMap as IM
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IS
-import GhcPlugins hiding ((<>), L, singleton)
+import qualified GhcPlugins as GHC
+import qualified Data.List as List
 import Types
 
 -- A set of simple inclusion constraints, i.e. k in X(d), grouped by X(d)
 newtype Guard
   = Guard
-      { groups :: HM.HashMap (DataType Name) (UniqSet Name)
+      { groups :: HM.HashMap (DataType GHC.Name) (GHC.UniqSet GHC.Name)
       }
   deriving (Eq)
 
 instance Semigroup Guard where
-  Guard g <> Guard g' = Guard (HM.unionWith unionUniqSets g g')
+  Guard g <> Guard g' = Guard (HM.unionWith GHC.unionUniqSets g g')
 
 instance Monoid Guard where
   mempty = Guard mempty
 
-instance Outputable Guard where
+instance GHC.Outputable Guard where
   ppr (Guard g) =
-    pprWithCommas (\(d, k) -> hsep [ppr k, text "in", ppr d]) $
-      second nonDetEltsUniqSet <$> HM.toList g
+    GHC.pprWithCommas (\(d, k) -> GHC.hsep [GHC.ppr k, GHC.text "in", GHC.ppr d]) $
+      second GHC.nonDetEltsUniqSet <$> HM.toList g
 
 instance Binary Guard where
-  put_ bh (Guard g) = put_ bh (HM.toList $ fmap nonDetEltsUniqSet g)
-  get bh = Guard . HM.fromList . fmap (second mkUniqSet) <$> Binary.get bh
+  put_ bh (Guard g) = put_ bh (HM.toList $ fmap GHC.nonDetEltsUniqSet g)
+  get bh = Guard . HM.fromList . fmap (second GHC.mkUniqSet) <$> Binary.get bh
 
 instance Refined Guard where
   domain (Guard g) = HM.foldrWithKey ((const . (<>)) . domain) mempty g
@@ -60,16 +61,16 @@ instance Refined Guard where
       )
 
 -- A guard literal
-singleton :: Name -> DataType Name -> Guard
-singleton k d = Guard (HM.singleton d (unitUniqSet k))
+singleton :: GHC.Name -> DataType GHC.Name -> Guard
+singleton k d = Guard (HM.singleton d (GHC.unitUniqSet k))
 
 -- Remove a list of constraints from a guard
-removeFromGuard :: [Name] -> DataType Name -> Guard -> Guard
+removeFromGuard :: [GHC.Name] -> DataType GHC.Name -> Guard -> Guard
 removeFromGuard k d = Guard . HM.update removeFromGroup d . groups
   where
     removeFromGroup ks =
-      let ks' = delListFromUniqSet ks k
-       in if isEmptyUniqSet ks'
+      let ks' = GHC.delListFromUniqSet ks k
+       in if GHC.isEmptyUniqSet ks'
             then Nothing
             else Just ks'
 
@@ -81,7 +82,7 @@ data Constraint l r
       { left :: K l,
         right :: K r,
         guard :: Guard,
-        srcSpan :: SrcSpan
+        srcSpan :: GHC.SrcSpan
       }
 
 -- Disregard location in comparison
@@ -89,10 +90,10 @@ instance Eq (Constraint l r) where
   Constraint l r g _ == Constraint l' r' g' _ = l == l' && r == r' && g == g'
 
 instance Hashable (Constraint l r) where
-  hashWithSalt s c = hashWithSalt s (left c, right c, second nonDetEltsUniqSet <$> HM.toList (groups (guard c)))
+  hashWithSalt s c = hashWithSalt s (left c, right c, second GHC.nonDetEltsUniqSet <$> HM.toList (groups (guard c)))
 
-instance Outputable (Constraint l r) where
-  ppr a = ppr (guard a) <+> char '?' <+> ppr (left a) <+> arrowt <+> ppr (right a)
+instance GHC.Outputable (Constraint l r) where
+  ppr a = GHC.ppr (guard a) GHC.<+> GHC.char '?' GHC.<+> GHC.ppr (left a) GHC.<+> GHC.arrowt GHC.<+> GHC.ppr (right a)
 
 instance (Binary (K l), Binary (K r)) => Binary (Constraint l r) where
   put_ bh c = put_ bh (left c) >> put_ bh (right c) >> put_ bh (guard c) >> put_ bh (Constraints.srcSpan c)
@@ -119,8 +120,8 @@ impliedBy a a'
           HM.foldMapWithKey
             ( \d ks ->
                 case HM.lookup d g of
-                  Nothing -> All (isEmptyUniqSet ks)
-                  Just ks' -> All (uniqSetAll (`elementOfUniqSet` ks') ks)
+                  Nothing -> All (GHC.isEmptyUniqSet ks)
+                  Just ks' -> All (GHC.uniqSetAll (`GHC.elementOfUniqSet` ks') ks)
             )
             g'
 impliedBy _ _ = False
@@ -137,9 +138,9 @@ tautology a =
       case right a of
         Dom d ->
           case HM.lookup d (groups (guard a)) of
-            Just ks -> elementOfUniqSet k ks
+            Just ks -> GHC.elementOfUniqSet k ks
             Nothing -> False
-        Set ks _ -> elementOfUniqSet k ks
+        Set ks _ -> GHC.elementOfUniqSet k ks
 
 -- A constraint that defines a refinement variable which also appears in the guard
 -- i.e. k in X(d) ? Y(d) => X(d)
@@ -150,7 +151,7 @@ recursive a =
     Dom d ->
       case HM.lookup d (groups (guard a)) of
         Nothing -> False
-        Just ks -> not (isEmptyUniqSet ks)
+        Just ks -> not (GHC.isEmptyUniqSet ks)
     Set _ _ -> False
 
 -- Apply the saturation rules in one direction
@@ -168,7 +169,7 @@ resolve l r =
             case left l of
               Dom d' ->
                 -- l is of shape d' <= d
-                case nonDetEltsUniqSet <$> HM.lookup d (groups (guard r)) of
+                case GHC.nonDetEltsUniqSet <$> HM.lookup d (groups (guard r)) of
                   Nothing -> []
                   Just ks ->
                     let rmdGuards = removeFromGuard ks d guards
@@ -178,80 +179,98 @@ resolve l r =
        in filter (not . tautology) (trans ++ weak) -- Remove redundant constriants
     Set _ _ -> []
 
-type ConstraintSet = ConstraintSetGen Atomic
+{-
+  The list `xs` associated with each variable inside the map `definite`
+  of shape, say, `[xs !! 1, xs !! 2, ..., xs !! k]` is a list of 
+  atomic constraints that obeys the following invariant: 
+  
+    for all i,j from 1 to k: 
+        not (xs !! i `impliedBy` xs !! j) 
+          && not (xs !! j `impliedBy` xs !! i)
 
-data ConstraintSetGen a
+  Since `impliedBy` is weaker than equality, it follows that such a 
+  list does not contain duplicates. 
+-}
+data ConstraintSet
   = ConstraintSet
-      { definite :: IM.IntMap (HS.HashSet a),
-        goal :: HS.HashSet a
+      { definite :: IntMap [Atomic],
+        goal :: [Atomic]
       }
-  deriving (Eq, Foldable)
+  deriving (Eq)
 
-instance (Hashable a, Eq a) => Semigroup (ConstraintSetGen a) where
-  cs <> cs' =
-    ConstraintSet
-      { definite = IM.unionWith HS.union (definite cs) (definite cs'),
-        goal = HS.union (goal cs) (goal cs')
-      }
+instance Semigroup ConstraintSet where
+  cs <> ds = fold insert ds cs            
 
-instance (Hashable a, Eq a) => Monoid (ConstraintSetGen a) where
-  mempty = ConstraintSet {definite = mempty, goal = mempty}
+instance Monoid ConstraintSet where
+  mempty = empty
 
-instance Outputable a => Outputable (ConstraintSetGen a) where
-  ppr = foldr (($$) . ppr) empty
+instance GHC.Outputable ConstraintSet where
+  ppr = fold ((GHC.$$) . GHC.ppr) GHC.empty
 
-instance (Binary a, Hashable a, Eq a) => Binary (ConstraintSetGen a) where
-  put_ bh cs = put_ bh (second HS.toList <$> IM.toList (definite cs)) >> put_ bh (HS.toList (goal cs))
-  get bh = ConstraintSet . IM.fromList . fmap (second HS.fromList) <$> Binary.get bh <*> (HS.fromList <$> Binary.get bh)
+instance Binary ConstraintSet where
+  put_ bh cs = put_ bh (IntMap.toList (definite cs)) >> put_ bh (goal cs) 
+  get bh = ConstraintSet . IntMap.fromList  <$> Binary.get bh <*> (Binary.get bh) 
 
-instance (Refined a, Hashable a, Eq a) => Refined (ConstraintSetGen a) where
-  domain = foldMap domain
-  rename x y cs =
-    ConstraintSet
-      { definite =
-          IM.fromListWith HS.union $
-            bimap (\z -> if z == x then y else z) (HS.map $ rename x y) <$> IM.toList (definite cs),
-        goal = HS.map (rename x y) (goal cs)
-      }
+instance Refined ConstraintSet where
+  domain cs = foldMap (foldMap domain) (definite cs) <> foldMap domain (goal cs)
+  rename x y cs = fold (\a ds -> insert (rename x y a) ds) empty cs
+
+empty :: ConstraintSet
+empty = ConstraintSet { definite = IntMap.empty, goal = []}
+
+fold :: (Atomic -> b -> b) -> b -> ConstraintSet -> b
+fold f z0 cs = z2
+  where
+    z1 = foldr (flip (foldr f)) z0 (definite cs)
+    z2 = foldr f z1 (goal cs)
+
+mapAction :: Monad m => (Atomic -> m ()) -> ConstraintSet -> m ()
+mapAction f cs = fold (\a b -> f a >> b) (return ()) cs
+
+insert' :: Atomic -> ConstraintSet -> (ConstraintSet, Bool)
+insert' a cs =
+  case right a of
+    Dom (Base _) -> (cs, False) -- Ignore constraints concerning base types
+    Dom (Inj x _) -> 
+      if any (a `impliedBy`) (IntMap.findWithDefault [] x (definite cs)) then
+        (cs, False) 
+      else 
+        let reducedDefs = 
+              filter (not . (`impliedBy` a)) (IntMap.findWithDefault [] x (definite cs))
+        in (cs { definite = IntMap.insert x (a:reducedDefs) (definite cs) }, True)
+    Set _ _ -> 
+      if any (a `impliedBy`) (goal cs) then
+        (cs, False)
+      else
+        let reducedGls = 
+              filter (not . (`impliedBy` a)) (goal cs)
+        in (cs { goal = a : reducedGls }, True)
 
 -- Add an atomic constriant to the set
+-- ensuring to maintain the invariant
 insert :: Atomic -> ConstraintSet -> ConstraintSet
-insert a cs =
-  case right a of
-    Dom (Base _) -> cs -- Ignore constraints concerning base types
-    Dom (Inj x _) -> cs {definite = IM.insertWith HS.union x (HS.singleton a) (definite cs)}
-    Set _ _ -> cs {goal = HS.insert a (goal cs)}
-
--- Check if a constraint will expand the minimum model
--- i.e. it is not already entailed by an existing constraint
-member :: Atomic -> ConstraintSet -> Bool
-member a cs =
-  case right a of
-    Dom (Inj x _)
-      | Just as <- IM.lookup x (definite cs) -> any (impliedBy a) as
-    Set _ _ -> any (impliedBy a) (goal cs)
-    _ -> False
+insert a = fst . insert' a
 
 -- Remove a constraint from a set
 remove :: Atomic -> ConstraintSet -> ConstraintSet
 remove a cs =
   case right a of
     Dom (Base _) -> cs -- Ignore constraints concerning base types
-    Dom (Inj x _) -> cs {definite = IM.update deleteA x (definite cs)}
-    Set _ _ -> cs {goal = HS.delete a (goal cs)}
+    Dom (Inj x _) -> cs {definite = IntMap.update deleteA x (definite cs)}
+    Set _ _ -> cs {goal = List.delete a (goal cs)}
   where
     deleteA as =
-      let as' = HS.delete a as
-       in if HS.null as'
+      let as' = List.delete a as
+       in if List.null as'
             then Nothing
             else Just as'
 
 -- Add a guard to every constraint
 guardWith :: Guard -> ConstraintSet -> ConstraintSet
 guardWith g cs =
-  ConstraintSet
-    { definite = IM.map (HS.map go) (definite cs),
-      goal = HS.map go (goal cs)
+  cs
+    { definite = IntMap.map (List.map go) (definite cs),
+      goal = map go (goal cs)
     }
   where
     go a = a {guard = g <> guard a}
@@ -271,21 +290,21 @@ eliminate :: Int -> ConstraintSet -> ConstraintSet
 eliminate i cs =
   ConstraintSet
     { definite =
-        IM.mapMaybeWithKey
+        IntMap.mapMaybeWithKey
           ( \x s ->
               if i == x
                 then Nothing
-                else Just $ HS.filter (IS.notMember i . domain) s
+                else Just $ List.filter (IS.notMember i . domain) s
           )
           (definite cs),
-      goal = HS.filter (IS.notMember i . domain) (goal cs)
+      goal = filter (IS.notMember i . domain) (goal cs)
     }
 
 -- One step consequence operator for saturation rules concerning a particular refinement variable
 saturateF :: Int -> RWS () Any ConstraintSet ()
 saturateF i =
   -- Lookup constraints with x in the head
-  gets (IM.lookup i . definite) >>= \case
+  gets (IntMap.lookup i . definite) >>= \case
     Just cs
       -- If there are only recursive clauses the minimum model is empty
       | not (all recursive cs) ->
@@ -293,11 +312,11 @@ saturateF i =
     _ -> return ()
   where
     addResolvant r = do
-      b <- gets (member r)
-      unless b $ do
-        modify (insert r)
-        tell (Any True)
+      ds <- Control.Monad.RWS.get 
+      let (ds', b) = insert' r ds
+      Control.Monad.RWS.put ds'
+      tell (Any b)
     resolveAllWith c = do
       ds <- Control.Monad.RWS.get
-      mapM_ (mapM_ addResolvant . resolve c) ds
+      mapAction (mapM_ addResolvant . resolve c) ds
       unless (recursive c) $ modify (remove c)

--- a/src/Constraints.hs
+++ b/src/Constraints.hs
@@ -180,9 +180,9 @@ resolve l r =
     Set _ _ -> []
 
 {-
-  The list `xs` associated with each variable inside the map `definite`
-  of shape, say, `[xs !! 1, xs !! 2, ..., xs !! k]` is a list of 
-  atomic constraints that obeys the following invariant: 
+  The lists of atomic constraints inside the set representation
+  of shape, say, `[xs !! 1, xs !! 2, ..., xs !! k]` obey the
+  following invariant: 
   
     for all i,j from 1 to k: 
         not (xs !! i `impliedBy` xs !! j) 


### PR DESCRIPTION
Since we check for `impliedBy` when inserting, this implies that there are no duplicates so there is no need to use a HashSet as part of the ConstraintSet representation.  Changed to lists.

When inserting new constraints also remove existing constraints implied by that which is inserted so that all ConstraintSets are antichains wrt impliedBy (this mainly improves readability of some of the test cases).