### PR TITLE
Sat speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist-newstyle/
 interface/
 profile/*.prof
 benchmarks/
+*.log
+*.prof
+profile.*
+*.hi
+*.o


### PR DESCRIPTION
- Eliminate existentials for mutually recursive functions on a per function basis
- Remove buggy dependency sort, which is unnecessary anyway since GHC provides the bindings in dependency sorted order
- Rework saturation and constraint representation/processing